### PR TITLE
Support colons in config keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,15 @@ There's a handy script to automate this process in `scripts/increment-version.sh
 
 Minor release: `make minor-release`
 Major release: `make major-relase`
+
+## Problems
+
+The first time you activate the virtualenv, you may need to run the following commands to install dev dependencies:
+
+```
+pip install psutil
+python setup.py develop
+```
+
+Attempting to install development packages can result in a "SandboxViolation" error when it attempts to install psutil.
+If you install psutil first, you will avoid the error.

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,4 @@
+import re
 import configparser
 import os
 from pathlib import Path
@@ -6,6 +7,14 @@ from src.util import get_valid_filename
 import click
 from termcolor import colored
 
+class CustomConfigParser(configparser.ConfigParser):
+    """Modified ConfigParser that allow ':' in keys and only '=' as separator.
+    """
+    OPTCRE = re.compile(
+        r'(?P<option>[^=\s][^=]*)'
+        r'\s*(?P<vi>[=])\s*'
+        r'(?P<value>.*)$'
+        )
 
 def get_config_file(first=False):
 
@@ -76,7 +85,7 @@ def make_config_files(config):
 
 
 def get_config():
-    config = configparser.ConfigParser()
+    config = CustomConfigParser()
     try:
         config.optionxform = str  # type: ignore
     except ValueError:


### PR DESCRIPTION
Resolves #8 

Testing:
Use the following kibbe config:
```
[kibana.params]
uiSettings.overrides.theme:darkMode=true
```

Run `kibbe kibana` and you'll see the colon is part of the config key:
```
node scripts/kibana --dev --uiSettings.overrides.theme:darkMode=true
```