### PR TITLE
Add prod option to kibbe kibana

### DIFF
--- a/src/commands/kibana.py
+++ b/src/commands/kibana.py
@@ -37,6 +37,13 @@ this = sys.modules[__name__]
     help="Shows an alterantive kibana loading log. Based on text parsing and regex.",
 )
 @click.option(
+    "--prod",
+    "-p",
+    default=False,
+    is_flag=True,
+    help="Runs Kibana in production mode (omits the '--dev' argument).",
+)
+@click.option(
     "--save-config",
     default=False,
     is_flag=True,
@@ -46,7 +53,7 @@ this = sys.modules[__name__]
     ),
 )
 @click.argument("unparsed_args", nargs=-1, type=click.UNPROCESSED)
-def kibana(save_config, unparsed_args, wait, alt):
+def kibana(save_config, unparsed_args, wait, alt, prod):
     """
     Runs Kibana from the current clone.
 
@@ -76,7 +83,10 @@ def kibana(save_config, unparsed_args, wait, alt):
         persist_config({"kibana.params": unparsed_to_map(params)})
         exit()
 
-    command = ["node", "scripts/kibana", "--dev"] + params
+    command = ["node", "scripts/kibana"]
+    if not prod:
+        command.append("--dev")
+    command.extend(params)
     click.echo("Will run kibana search as: " + colored(" ".join(command), "yellow"))
 
     if alt:

--- a/src/commands/kibana.py
+++ b/src/commands/kibana.py
@@ -57,7 +57,7 @@ def kibana(save_config, unparsed_args, wait, alt, prod):
     """
     Runs Kibana from the current clone.
 
-    You can pass the same parameters as you'd pass to `node scritps/kibana`
+    You can pass the same parameters as you'd pass to `node scripts/kibana`
 
     You can persist some parameters by using a configuration file `~/.kibbe`.
     with the [kibana.params] section.
@@ -177,7 +177,7 @@ def get_kibana_icon(message):
 
 def exit_():
     """
-    Makes sure that when exiting kibbe any remaninig subprocess is killed.
+    Makes sure that when exiting kibbe any remaining subprocess is killed.
     This is useful because if kibbe starts a nodejs process it might spawn
     more sub-proceses but they will not be terminated if the parent is asked to
     do so.


### PR DESCRIPTION
Resolves #10.

This adds the `--prod`/`-p` option to the `kibbe kibana` command.
When used, it omits the `--dev` argument when starting the Kibana server.

Also fixes a couple of typos that I noticed!